### PR TITLE
Add Chrome extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,19 @@ npm run build
 ```sh
 npm run lint
 ```
+
+## Chrome Extension Setup
+
+### Build the Chrome Extension
+
+```sh
+npm run build
+```
+
+### Load the Extension in Chrome
+
+1. Open Chrome and go to `chrome://extensions/`.
+2. Enable "Developer mode" by toggling the switch in the top right corner.
+3. Click on the "Load unpacked" button.
+4. Select the `dist` folder from the project directory.
+5. The extension should now be loaded and ready to use.

--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
 <body>
   <div id="app"></div>
   <script type="module" src="/src/main.js"></script>
+  <script src="background.js"></script>
+  <link rel="stylesheet" href="styles.css">
 </body>
 
 </html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,27 @@
+{
+  "manifest_version": 3,
+  "name": "HackClub AI ChatBot",
+  "version": "1.0",
+  "description": "A Chrome extension for the HackClub AI ChatBot",
+  "background": {
+    "service_worker": "src/background.js"
+  },
+  "permissions": [
+    "storage",
+    "activeTab",
+    "scripting"
+  ],
+  "action": {
+    "default_popup": "index.html",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    }
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
+import { resolve } from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -18,4 +19,12 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        manifest: resolve(__dirname, 'public/manifest.json')
+      }
+    }
+  }
 })


### PR DESCRIPTION
Add configuration for Chrome extension.

* **Add `manifest.json`**: Create `public/manifest.json` with necessary configuration for a Chrome extension, including `manifest_version`, `name`, `version`, `background` script, `permissions`, `action`, and `icons`.
* **Update `vite.config.js`**: Import `resolve` from 'path' and update the `build` configuration to include the `manifest.json` file in the output.
* **Modify `index.html`**: Add necessary scripts and styles for the Chrome extension.
* **Update `README.md`**: Add instructions on how to build and load the Chrome extension in Chrome.

