### PR TITLE
feat: take initial prompt from URL query parameter

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -123,11 +123,17 @@ onMounted(async () => {
   // Set the chat panel reference (used by useConversation for scrollToEnd, etc.)
   setChatPanel(chatPanelRef.value);
 
-  // Handle initial prompt from URL query parameter (e.g. /?initialPrompt=Hello)
-  const initialPrompt = route.query.initialPrompt;
+  // Handle initial prompt from URL query parameter (e.g. /?q=Hello)
+  const initialPrompt = route.query.q;
+  const initialModel = route.query.model;
   if (initialPrompt && typeof initialPrompt === 'string' && initialPrompt.trim()) {
     await nextTick();
-    messageFormRef.value?.setMessage(initialPrompt.trim());
+
+    if (initialModel && availableModels.value.some(m => m.name === initialModel)) {
+      settingsManager.setSelectedModel(initialModel);
+    }
+
+    await sendMessage(initialPrompt.trim());
   }
 });
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -125,12 +125,15 @@ onMounted(async () => {
 
   // Handle initial prompt from URL query parameter (e.g. /?q=Hello)
   const initialPrompt = route.query.q;
-  const initialModel = route.query.model;
+  let initialModel = route.query.model;
   if (initialPrompt && typeof initialPrompt === 'string' && initialPrompt.trim()) {
     await nextTick();
 
-    if (initialModel && availableModels.value.some(m => m.name === initialModel)) {
-      settingsManager.setSelectedModel(initialModel);
+    if (initialModel) {
+      initialModel = initialModel.replace('-', '/');
+      if (availableModels.value.find(m => m.name === initialModel)) {
+        settingsManager.setSelectedModel(initialModel);
+      }
     }
 
     await sendMessage(initialPrompt.trim());

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -122,6 +122,13 @@ onMounted(async () => {
 
   // Set the chat panel reference (used by useConversation for scrollToEnd, etc.)
   setChatPanel(chatPanelRef.value);
+
+  // Handle initial prompt from URL query parameter (e.g. /?initialPrompt=Hello)
+  const initialPrompt = route.query.initialPrompt;
+  if (initialPrompt && typeof initialPrompt === 'string' && initialPrompt.trim()) {
+    await nextTick();
+    messageFormRef.value?.setMessage(initialPrompt.trim());
+  }
 });
 
 // Use selectedModelName from settingsManager

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -44,7 +44,7 @@ import { useDark } from "@vueuse/core";
 import { useRoute, useRouter } from '#app';
 import { useHead } from '@unhead/vue';
 
-import { availableModels } from '~/composables/availableModels';
+import { availableModels, findModelById } from '~/composables/availableModels';
 import { useSettings } from '~/composables/useSettings';
 import { useConversation } from '~/composables/useConversation';
 import { useGlobalScrollStatus } from '~/composables/useGlobalScrollStatus';
@@ -125,14 +125,27 @@ onMounted(async () => {
 
   // Handle initial prompt from URL query parameter (e.g. /?q=Hello)
   const initialPrompt = route.query.q;
-  let initialModel = route.query.model;
+  const initialModel = route.query.model;
   if (initialPrompt && typeof initialPrompt === 'string' && initialPrompt.trim()) {
     await nextTick();
 
-    if (initialModel) {
-      initialModel = initialModel.replace('-', '/');
-      if (availableModels.value.find(m => m.name === initialModel)) {
-        settingsManager.setSelectedModel(initialModel);
+    if (typeof initialModel === 'string' && initialModel.trim()) {
+      const normalizedModel = decodeURIComponent(initialModel).trim();
+      const modelCandidates = [
+        normalizedModel,
+        normalizedModel.includes('/') ? null : normalizedModel.replace('-', '/'),
+      ].filter(Boolean);
+
+      const matchedModel = modelCandidates
+        .map(candidate => findModelById(availableModels, candidate))
+        .find(Boolean);
+
+      const matchedByName = availableModels
+        .flatMap(category => category.models || [])
+        .find(model => model.name.toLowerCase() === normalizedModel.toLowerCase());
+
+      if (matchedModel || matchedByName) {
+        settingsManager.settings.selected_model_id = (matchedModel || matchedByName).id;
       }
     }
 


### PR DESCRIPTION
Hi @Mostlime12195 ! I would love it if we could set the initial prompt from a redirect. With this PR, when a user visits the page with an `initialPrompt` parameter, the chat input is automatically pre-filled with its value.